### PR TITLE
hotfix(registry): handle direct registry.json requests

### DIFF
--- a/app/registry/[componentName]/route.ts
+++ b/app/registry/[componentName]/route.ts
@@ -5,9 +5,23 @@ import { NextResponse } from 'next/server';
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ componentName: string }> }
-
 ) {
   let { componentName } = await params;
+  
+  if (componentName === 'registry' || componentName === 'registry.json') {
+    try {
+      const registryFilePath = join(process.cwd(), 'registry.json');
+      const registryFileContent = readFileSync(registryFilePath, 'utf-8');
+      const registryData = JSON.parse(registryFileContent);
+
+      return NextResponse.json(registryData);
+    } catch (error) {
+      return new NextResponse(
+        JSON.stringify({ error: `Registry file not found: ${error}` }),
+        { status: 404, headers: { 'content-type': 'application/json' } }
+      );
+    }
+  }
   
   // Supprimer l'extension .json si elle est présente
   if (componentName.endsWith('.json')) {


### PR DESCRIPTION
Add special case handling for 'registry' and 'registry.json' requests to serve the full registry data. Include error handling when the registry file is not found.